### PR TITLE
feat: open stdin & allocate tty on dev services

### DIFF
--- a/tutorxqueue/patches/local-docker-compose-dev-services
+++ b/tutorxqueue/patches/local-docker-compose-dev-services
@@ -1,0 +1,7 @@
+xqueue:
+  stdin_open: true
+  tty: true
+
+xqueue-consumer:
+  stdin_open: true
+  tty: true


### PR DESCRIPTION
This ensures that services started with `tutor dev start`
are as capable for breakpoint debugging, et al, as services
started with `tutor dev runserver` are. We plan to remove
`tutor dev runserver`.

Blocks https://github.com/overhangio/tutor/pull/644