### PR TITLE
feat: add COMPOSE_MOUNTS for xqueue

### DIFF
--- a/tutorxqueue/plugin.py
+++ b/tutorxqueue/plugin.py
@@ -57,6 +57,20 @@ tutor_hooks.Filters.IMAGES_PUSH.add_item((
     "{{ XQUEUE_DOCKER_IMAGE }}",
 ))
 
+@tutor_hooks.Filters.COMPOSE_MOUNTS.add()
+def _mount_xqueue(volumes, name):
+    """
+    When mounting xqueue with `--mount=/path/to/xqueue`,
+    bind-mount the host repo in the xqueue container.
+    """
+    if name == "xqueue":
+        path = "/openedx/xqueue"
+        volumes += [
+            ("xqueue", path),
+            ("xqueue-job", path),
+        ]
+    return volumes
+
 @click.group(help="Interact with the Xqueue server", name="xqueue")
 def command():
     pass


### PR DESCRIPTION
Part of https://github.com/overhangio/2u-tutor-adoption/issues/26

In order to remove `runserver`, the following must be done for all official tutor plugins:

- [X] Ensure that the plugin is ported to the V1 API
- [ ] Ensure that the plugin hooks into the COMPOSE_MOUNTS filter in order to automatically bind-mount folders as appropriate.
- [X] Replace any references to runserver with start
- [X] Replace any references to the --volume option with an equivalent usage of the --mount option.

Within this repo, there was only one incomplete task: 'Ensure that the plugin hooks into the `COMPOSE_MOUNTS` filter in order to automatically bind-mount folders as appropriate.'. This task is solved with this PR.

A `COMPOSE_MOUNTS` function has been added to easily mount
`xqueue` to `/openedx/xqueue`

It was tested by installing the plugin and mounting a local `xqueue` via `tutor dev run xqueue --mount=/path/to/xqueue bash`, and checking that files changed or created within the container's bash shell could be found in the local `xqueue` directory, and vice versa.