### PR TITLE
feat: add COMPOSE_MOUNT feature instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,15 @@ Configuration
 
 These values can be modified with ``tutor config save --set PARAM_NAME=VALUE`` commands.
 
+Debugging
+---------
+
+To debug the xqueue service, you are encouraged to mount the xqueue repo from the host in the development container:
+
+    tutor dev start --mount /path/to/xqueue
+
+Feel free to add breakpoints (``breakpoint()``) anywhere in your source code to debug your application.
+
 License
 -------
 


### PR DESCRIPTION
A COMPOSE_MOUNT feature was added to the tutor-xqueue plugin, but instructions were not included in the original PR (https://github.com/overhangio/tutor-xqueue/pull/9). This PR adds instructions for how to use `--mount` to the README.

closes https://github.com/overhangio/tutor-xqueue/issues/10