### PR TITLE
docs: change quickstart to launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Then, to enable this plugin, run::
 
     tutor plugins enable xqueue
 
-You should then run the initialisation scripts. The easiest way to do this is to run ``tutor local quickstart``.
+You should then run the initialisation scripts. The easiest way to do this is to run ``tutor local launch``.
 
 Usage
 -----


### PR DESCRIPTION
This change is due to quickstart being renamed to launch in tutor.
See https://github.com/overhangio/tutor/pull/724