### PR TITLE
Fix broken media download

### DIFF
--- a/tutorxqueue/templates/xqueue/build/xqueue/Dockerfile
+++ b/tutorxqueue/templates/xqueue/build/xqueue/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir /openedx/data /openedx/data/media
 
 EXPOSE 8000
 CMD uwsgi \
-    --static-map /media=/openedx/media/ \
+    --static-map /media=/openedx/data/media/ \
     --http 0.0.0.0:8000 \
     --thunder-lock \
     --single-interpreter \


### PR DESCRIPTION
The static map used with uwsgi was referencing the wrong media directory, such that downloads of media files did not work correctly.