### PR TITLE
chore: remove xqueue permissions container.

### DIFF
--- a/changelog.d/20230731_080653_jhony.avella_remove_permissions_container.md
+++ b/changelog.d/20230731_080653_jhony.avella_remove_permissions_container.md
@@ -1,0 +1,1 @@
+- [Improvement] Removing the xqueue permissions container in favor of a global single permissions container. (by @jfavellar90)

--- a/tutorxqueue/patches/local-docker-compose-permissions-command
+++ b/tutorxqueue/patches/local-docker-compose-permissions-command
@@ -1,0 +1,1 @@
+setowner 1000 /mounts/xqueue

--- a/tutorxqueue/patches/local-docker-compose-permissions-volumes
+++ b/tutorxqueue/patches/local-docker-compose-permissions-volumes
@@ -1,0 +1,1 @@
+- ../../data/xqueue/media:/mounts/xqueue

--- a/tutorxqueue/patches/local-docker-compose-services
+++ b/tutorxqueue/patches/local-docker-compose-services
@@ -9,13 +9,6 @@ xqueue:
   restart: unless-stopped
   depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}
 
-xqueue-permissions:
-  image: {{ DOCKER_IMAGE_PERMISSIONS }}
-  command: ["1000", "/openedx/xqueue"]
-  restart: on-failure
-  volumes:
-    - ../../data/xqueue/media:/openedx/xqueue
-
 xqueue-consumer:
   image: {{ XQUEUE_DOCKER_IMAGE }}
   volumes:


### PR DESCRIPTION
There is now a single "permissions" container that makes all permission changes in the Tutor core. See this commit for reference: https://github.com/overhangio/tutor/commit/bfa1f657282d53f8a9c1820ebcb27d630836ac58