### PR TITLE
Fix: Typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ You should then run the initialisation scripts. The easiest way to do this is to
 Usage
 -----
 
-In the Open edX studio, edit a course and add a new "Advanced blank problem" ("Problem" 🠆 "Advanced" 🠆  "Blank Advanced Problem"). Then, click "Edit" and copy-paste the following in the editor::
+In the Open edX studio, edit a course and add a new "Advanced blank problem" ("Problem" → "Advanced" →  "Blank Advanced Problem"). Then, click "Edit" and copy-paste the following in the editor::
 
 
     <problem>

--- a/tutorxqueue/plugin.py
+++ b/tutorxqueue/plugin.py
@@ -36,7 +36,7 @@ config = {
 # Initialization hooks
 
 # To add a custom initialization task, create a bash script template under:
-# tutorcodejail/templates/codejail/tasks/
+# tutorxqueue/templates/xqueue/tasks/
 # and then add it to the MY_INIT_TASKS list. Each task is in the format:
 # ("<service>", ("<path>", "<to>", "<script>", "<template>"))
 MY_INIT_TASKS: list[tuple[str, tuple[str, ...]]] = [


### PR DESCRIPTION
Hi
noticed there are a couple of 🠆 characters in the readme. replaced them with ->
and also a codejail mention was replaced with xqueue