### PR TITLE
fix: add missing pkg-config package

### DIFF
--- a/tutorxqueue/templates/xqueue/build/xqueue/Dockerfile
+++ b/tutorxqueue/templates/xqueue/build/xqueue/Dockerfile
@@ -7,7 +7,14 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/var/cache/apt,shari
     --mount=type=cache,target=/var/lib/apt,sharing=locked{% endif %} \
     apt update && \
     apt upgrade -y && \
-    apt install -y language-pack-en git python3 python3-pip python3-venv libmysqlclient-dev
+    apt install -y \
+        language-pack-en \
+        git \
+        python3 \
+        python3-pip \
+        python3-venv \
+        libmysqlclient-dev \
+        pkg-config
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ###### Git-clone xqueue repo ######


### PR DESCRIPTION
Build fails in nightly with the following error:

	#28 5.503   × Getting requirements to build wheel did not run
	    successfully.
	#28 5.503   │ exit code: 1
	#28 5.503   ╰─> [24 lines of output]
	#28 5.503       /bin/sh: 1: pkg-config: not found
	#28 5.503       /bin/sh: 1: pkg-config: not found
	#28 5.503       Trying pkg-config --exists mysqlclient
	#28 5.503       Command 'pkg-config --exists mysqlclient' returned
	    non-zero exit status 127.
	#28 5.503       Trying pkg-config --exists mariadb
	#28 5.503       Command 'pkg-config --exists mariadb' returned non-zero
	    exit status 127.
	#28 5.503       Traceback (most recent call last):
	#28 5.503         File
	    "/openedx/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
	line 353, in <module>
	#28 5.503           main()
	#28 5.503         File
	    "/openedx/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
	line 335, in main
	#28 5.503           json_out['return_val'] =
	    hook(**hook_input['kwargs'])
	#28 5.503         File
	    "/openedx/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
	line 118, in get_requires_for_build_wheel
	#28 5.503           return hook(config_settings)
	#28 5.503         File
	    "/tmp/pip-build-env-58chejnv/overlay/lib/python3.8/site-packages/setuptools/build_meta.py",
	line 355, in get_requires_for_build_wheel
	#28 5.503           return self._get_build_requires(config_settings,
	    requirements=['wheel'])
	#28 5.503         File
	    "/tmp/pip-build-env-58chejnv/overlay/lib/python3.8/site-packages/setuptools/build_meta.py",
	line 325, in _get_build_requires
	#28 5.503           self.run_setup()
	#28 5.503         File
	    "/tmp/pip-build-env-58chejnv/overlay/lib/python3.8/site-packages/setuptools/build_meta.py",
	line 341, in run_setup
	#28 5.503           exec(code, locals())
	#28 5.503         File "<string>", line 154, in <module>
	#28 5.503         File "<string>", line 48, in get_config_posix
	#28 5.503         File "<string>", line 27, in find_package_name
	#28 5.503       Exception: Can not find valid pkg-config name.
	#28 5.503       Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env
	    vars manuallY