### PR TITLE
chore: remove python 3.8 references and set py39 as minimum version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/changelog.d/20241111_170333_dawoud.sheraz_remove_py38_references.md
+++ b/changelog.d/20241111_170333_dawoud.sheraz_remove_py38_references.md
@@ -1,0 +1,1 @@
+- 💥 [Deprecation] Drop support for python 3.8 and set Python 3.9 as the minimum supported python version. (by @DawoudSheraz)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["tutor>=18.0.0,<19.0.0", "requests"],
     extras_require={
         "dev": ["tutor[dev]>=18.0.0,<19.0.0"],
@@ -44,7 +44,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Achieves part of https://github.com/overhangio/tutor/issues/1129

- Update Python 3.8 references to 3.9
- Update Github actions to use 3.9