### PR TITLE
Chore: Change XQUEUE_REPOSITORY_VERSION to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ instructions, because git commits are used to generate release notes:
 
 - [Improvement] Migrate from pylint and black to ruff. (by @rehmansheikh222)
 - [Improvement] Test python package distribution build when running make test. (by @rehmansheikh222)
-
 - 💥[Feature] Upgrade to Ulmo. (by @jfavellar90)
+- [Chore] Change XQUEUE_REPOSITORY_VERSION to master as a temporary fix to unblock tutor ulmo release. (by @Faraz32123)
 
 <a id='changelog-20.0.0'></a>
 ## v20.0.0 (2025-06-05)

--- a/tutorxqueue/plugin.py
+++ b/tutorxqueue/plugin.py
@@ -28,7 +28,9 @@ config: dict[str, dict[str, Any]] = {
         "MYSQL_DATABASE": "xqueue",
         "MYSQL_USERNAME": "xqueue",
         "REPOSITORY": "https://github.com/openedx/xqueue",
-        "REPOSITORY_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
+        # TODO: revert REPOSITORY_VERSION to "{{ OPENEDX_COMMON_VERSION }}"
+        # once openedx/xqueue has released an ulmo branch
+        "REPOSITORY_VERSION": "master",
     },
     "unique": {
         "AUTH_PASSWORD": "{{ 8|random_string }}",


### PR DESCRIPTION
Change `XQUEUE_REPOSITORY_VERSION` to `master` as a temporary fix to **unblock tutor** [**ulmo**](https://github.com/overhangio/tutor/blob/3cf06bcbe097e81a9d028be9aaab56a1d3aafe13/requirements/plugins.txt#L14) release becasue [openedx/xqueue](https://github.com/openedx/xqueue) has release an ulmo branch.